### PR TITLE
Allow compiling against elixir 1.3.0

### DIFF
--- a/lib/table_rex/renderer/text/meta.ex
+++ b/lib/table_rex/renderer/text/meta.ex
@@ -5,18 +5,14 @@ defmodule TableRex.Renderer.Text.Meta do
   """
   alias TableRex.Renderer.Text.Meta
 
-  def __struct__ do
-    %{
-      col_widths: %{},
-      row_heights: %{},
-      table_width: 0,
-      intersections: [],
-      render_horizontal_frame?: false,
-      render_vertical_frame?: false,
-      render_column_separators?: false,
-      render_row_separators?: false
-     }
-  end
+  defstruct col_widths: %{},
+            row_heights: %{},
+            table_width: 0,
+            intersections: [],
+            render_horizontal_frame?: false,
+            render_vertical_frame?: false,
+            render_column_separators?: false,
+            render_row_separators?: false
 
   @doc """
   Retreives the "inner width" of the table, which is the full width minus any frame.


### PR DESCRIPTION
I recently upgraded to elixir 1.3. After doing so I noticed that compiling of one of the dependencies failed to compile. Upon `mix compile` with Erlang 19.0 and elixir 1.3 I got:

```
== Compilation error on file lib/table_rex/renderer/text.ex ==
** (CompileError) lib/table_rex/renderer/text.ex:53: TableRex.Renderer.Text.Meta.__struct__/1 is undefined, cannot expand struct TableRex.Renderer.Text.Meta
could not compile dependency :table_rex, "mix compile" failed. You can recompile this dependency with "mix deps.compile table_rex", update it with "mix deps.update table_rex" or clean it with "mix deps.clean table_rex"
```

This PR uses an explicit `defstruct` instead of `def __struct__ do...` to declare the _Meta_ struct.

Cleaning the build files and deleting the _deps_ directory hadn't helped, by using `defstruct` everything compiles fine. I'm not touching elixir code every day, so in case I missed anything, please let me know.