### PR TITLE
Add support to render header, column, and cell with color.  Closes #8

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,5 +7,6 @@ Contributors
 ============
 
 * **[Charles FD](https://github.com/freiden)**
+* **[Justin G](https://github.com/theredcoder)**
 
 Please add yourself if making a contribution.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Currently supports output:
 * A one-liner for those that just want to render ASCII tables with sane defaults.
 * Support for table titles & alignable headers.
 * Support for column & cell level alignment (center, left, right).
+* Support for column, header, & cell level color.
 * Automatic cell padding but also the option to set padding per column<sup>1</sup>.
 * Frame the table with various vertical & horizontal styles<sup>1</sup>.
 * Style the table how you wish with custom separators<sup>1</sup>.
@@ -198,6 +199,33 @@ Table.new(rows, header)
 | Marcus Intalex | Temperance    |            Soul:r | 2004 |
 | Kryptic Minds  | The Forgotten | Defcom Records    | 2007 |
 +----------------+---------------+-------------------+------+
+```
+
+**Set color for the column, header, and cell:**
+```elixir
+Table.new(rows, header)
+|> Table.put_column_meta(0, color: :red) # sets column header to red, too
+|> Table.put_header_meta(1..4, color: IO.ANSI.color(31))
+|> Table.put_cell_meta(2, 1, color: [:green_background, :white])
+|> Table.render!
+|> IO.puts
+```
+
+*Supported color value types:*
+
+* atom: a named ANSI sequence defined in [IO.ANSI](https://hexdocs.pm/elixir/IO.ANSI.html#content)
+* string: an embedded ANSI sequence
+* chardata: a list of atoms and/or strings
+* function: `(text, value) -> text`
+  * where text is the padded value and where the value is a string
+  * **Note:** to render the correct padding, always format and return the text
+
+**Conditionally set a color:**
+```elixir
+Table.new(rows, header)
+|> Table.put_column_meta(3, color: fn(text, value) -> if value in ["1999", "2007"], do: [:blue, text], else: text end)
+|> Table.render!
+|> IO.puts
 ```
 
 **Change/pass in your own renderer module:**

--- a/lib/table_rex/cell.ex
+++ b/lib/table_rex/cell.ex
@@ -4,7 +4,7 @@ defmodule TableRex.Cell do
   """
   alias TableRex.Cell
 
-  defstruct value: "", align: nil
+  defstruct value: "", align: nil, color: nil
 
   @type t :: %__MODULE__{}
 

--- a/lib/table_rex/column.ex
+++ b/lib/table_rex/column.ex
@@ -3,7 +3,7 @@ defmodule TableRex.Column do
   Defines a struct that represents a column's metadata
   """
 
-  defstruct align: :left, padding: 1
+  defstruct align: :left, padding: 1, color: nil
 
   @type t :: %__MODULE__{}
 

--- a/lib/table_rex/renderer/text.ex
+++ b/lib/table_rex/renderer/text.ex
@@ -203,7 +203,9 @@ defmodule TableRex.Renderer.Text do
     col_width = Meta.col_width(meta, col_index)
     col_padding = Table.get_column_meta(table, col_index, :padding)
     cell_align = Map.get(cell, :align) || Table.get_column_meta(table, col_index, :align)
+    cell_color = Map.get(cell, :color) || Table.get_column_meta(table, col_index, :color)
     do_render_cell(cell.value, col_width, col_padding, align: cell_align)
+    |> format_with_color(cell.value, cell_color)
   end
 
   defp do_render_cell(value, inner_width) do
@@ -298,5 +300,17 @@ defmodule TableRex.Renderer.Text do
     |> Enum.reverse
     |> Enum.join("\n")
     |> Kernel.<>("\n")
+  end
+
+  defp format_with_color(text, _, nil), do: text
+
+  defp format_with_color(text, value, color) when is_function(color) do
+    [color.(text, value) | IO.ANSI.reset]
+    |> IO.ANSI.format_fragment(true)
+  end
+
+  defp format_with_color(text, _, color) do
+    [[color | text] | IO.ANSI.reset]
+    |> IO.ANSI.format_fragment(true)
   end
 end

--- a/test/table_rex/cell_test.exs
+++ b/test/table_rex/cell_test.exs
@@ -7,7 +7,8 @@ defmodule TableRex.CellTest do
   test "default struct" do
     assert %Cell{} == %Cell{
       value: "",
-      align: nil
+      align: nil,
+      color: nil
     }
   end
 
@@ -24,7 +25,7 @@ defmodule TableRex.CellTest do
   end
 
   test "to_cell with binary & opts" do
-    %Cell{value: "Thirteen", align: :left} = Cell.to_cell("Thirteen", align: :left)
+    %Cell{value: "Thirteen", align: :left, color: :red} = Cell.to_cell("Thirteen", align: :left, color: :red)
   end
 
   test "to_cell with %Cell{value: float}" do

--- a/test/table_rex/renderer/text_test.exs
+++ b/test/table_rex/renderer/text_test.exs
@@ -740,6 +740,78 @@ defmodule TableRex.Renderer.TextTest do
     """
   end
 
+  test "default render with added color using a named ANSI sequence", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_column_meta(1, color: :red)
+      |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    |          Renegade Hardware Releases          |
+    +----------------+----------------------+------+
+    | Artist         |\e[31m Track                \e[0m| Year |
+    +----------------+----------------------+------+
+    | Konflict       |\e[31m Cyanide              \e[0m| 1999 |
+    | Keaton & Hive  |\e[31m The Plague           \e[0m| 2003 |
+    | Vicious Circle |\e[31m Welcome To Shanktown \e[0m| 2007 |
+    +----------------+----------------------+------+
+    """
+  end
+
+  test "default render with added color using an embedded ANSI sequence", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_column_meta(1, color: "\e[31m")
+      |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    |          Renegade Hardware Releases          |
+    +----------------+----------------------+------+
+    | Artist         |\e[31m Track                \e[0m| Year |
+    +----------------+----------------------+------+
+    | Konflict       |\e[31m Cyanide              \e[0m| 1999 |
+    | Keaton & Hive  |\e[31m The Plague           \e[0m| 2003 |
+    | Vicious Circle |\e[31m Welcome To Shanktown \e[0m| 2007 |
+    +----------------+----------------------+------+
+    """
+  end
+
+  test "default render with added color using multiple ANSI sequences", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_column_meta(1, color: ["\e[48;5;30m", :white])
+      |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    |          Renegade Hardware Releases          |
+    +----------------+----------------------+------+
+    | Artist         |\e[48;5;30m\e[37m Track                \e[0m| Year |
+    +----------------+----------------------+------+
+    | Konflict       |\e[48;5;30m\e[37m Cyanide              \e[0m| 1999 |
+    | Keaton & Hive  |\e[48;5;30m\e[37m The Plague           \e[0m| 2003 |
+    | Vicious Circle |\e[48;5;30m\e[37m Welcome To Shanktown \e[0m| 2007 |
+    +----------------+----------------------+------+
+    """
+  end
+
+  test "default render with added color using a function", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_column_meta(2, color: fn(t, v) -> if v in ["1999", "2007"], do: [:blue, t], else: t end)
+      |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    |          Renegade Hardware Releases          |
+    +----------------+----------------------+------+
+    | Artist         | Track                | Year \e[0m|
+    +----------------+----------------------+------+
+    | Konflict       | Cyanide              |\e[34m 1999 \e[0m|
+    | Keaton & Hive  | The Plague           | 2003 \e[0m|
+    | Vicious Circle | Welcome To Shanktown |\e[34m 2007 \e[0m|
+    +----------------+----------------------+------+
+    """
+  end
+
   test "default render with increases padding across all rows (using list)", %{table: table} do
     {:ok, rendered} =
       table
@@ -792,6 +864,24 @@ defmodule TableRex.Renderer.TextTest do
     """
   end
 
+  test "default render with set column meta color across all columns", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_column_meta(:all, color: :red)
+      |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    |          Renegade Hardware Releases          |
+    +----------------+----------------------+------+
+    |\e[31m Artist         \e[0m|\e[31m Track                \e[0m|\e[31m Year \e[0m|
+    +----------------+----------------------+------+
+    |\e[31m Konflict       \e[0m|\e[31m Cyanide              \e[0m|\e[31m 1999 \e[0m|
+    |\e[31m Keaton & Hive  \e[0m|\e[31m The Plague           \e[0m|\e[31m 2003 \e[0m|
+    |\e[31m Vicious Circle \e[0m|\e[31m Welcome To Shanktown \e[0m|\e[31m 2007 \e[0m|
+    +----------------+----------------------+------+
+    """
+  end
+
   test "default render with set column meta across all columns and specific column override", %{table: table} do
     {:ok, rendered} =
       table
@@ -831,6 +921,78 @@ defmodule TableRex.Renderer.TextTest do
     """
   end
 
+  test "default render with cell level color using a named ANSI sequence", %{table: table} do
+    {:ok, rendered} =
+      table
+    |> Table.put_cell_meta(1, 1, color: :red)
+    |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    |          Renegade Hardware Releases          |
+    +----------------+----------------------+------+
+    | Artist         | Track                | Year |
+    +----------------+----------------------+------+
+    | Konflict       | Cyanide              | 1999 |
+    | Keaton & Hive  |\e[31m The Plague           \e[0m| 2003 |
+    | Vicious Circle | Welcome To Shanktown | 2007 |
+    +----------------+----------------------+------+
+    """
+  end
+
+  test "default render with cell level color using an embedded ANSI sequence", %{table: table} do
+    {:ok, rendered} =
+      table
+    |> Table.put_cell_meta(1, 1, color: "\e[31m")
+    |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    |          Renegade Hardware Releases          |
+    +----------------+----------------------+------+
+    | Artist         | Track                | Year |
+    +----------------+----------------------+------+
+    | Konflict       | Cyanide              | 1999 |
+    | Keaton & Hive  |\e[31m The Plague           \e[0m| 2003 |
+    | Vicious Circle | Welcome To Shanktown | 2007 |
+    +----------------+----------------------+------+
+    """
+  end
+
+  test "default render with cell level color using multiple ANSI sequences", %{table: table} do
+    {:ok, rendered} =
+      table
+    |> Table.put_cell_meta(1, 1, color: ["\e[48;5;30m", :white])
+    |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    |          Renegade Hardware Releases          |
+    +----------------+----------------------+------+
+    | Artist         | Track                | Year |
+    +----------------+----------------------+------+
+    | Konflict       | Cyanide              | 1999 |
+    | Keaton & Hive  |\e[48;5;30m\e[37m The Plague           \e[0m| 2003 |
+    | Vicious Circle | Welcome To Shanktown | 2007 |
+    +----------------+----------------------+------+
+    """
+  end
+
+  test "default render with cell level color using a function", %{table: table} do
+    {:ok, rendered} =
+      table
+    |> Table.put_cell_meta(1, 1, color: fn(t, _) -> ["\e[48;5;30m", :white, t] end)
+    |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    |          Renegade Hardware Releases          |
+    +----------------+----------------------+------+
+    | Artist         | Track                | Year |
+    +----------------+----------------------+------+
+    | Konflict       | Cyanide              | 1999 |
+    | Keaton & Hive  |\e[48;5;30m\e[37m The Plague           \e[0m| 2003 |
+    | Vicious Circle | Welcome To Shanktown | 2007 |
+    +----------------+----------------------+------+
+    """
+  end
+
   test "default render with header cell alignment", %{table: table} do
     {:ok, rendered} =
       table
@@ -850,4 +1012,60 @@ defmodule TableRex.Renderer.TextTest do
     """
   end
 
+  test "default render with header cell color", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_header_meta(0, color: :red)
+      |> Table.put_header_meta(1, color: :blue)
+      |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    |          Renegade Hardware Releases          |
+    +----------------+----------------------+------+
+    |\e[31m Artist         \e[0m|\e[34m Track                \e[0m| Year |
+    +----------------+----------------------+------+
+    | Konflict       | Cyanide              | 1999 |
+    | Keaton & Hive  | The Plague           | 2003 |
+    | Vicious Circle | Welcome To Shanktown | 2007 |
+    +----------------+----------------------+------+
+    """
+  end
+
+  test "default render with set column meta color across all columns and specific header override", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_column_meta(1, color: :red)
+      |> Table.put_header_meta(1, color: :blue)
+      |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    |          Renegade Hardware Releases          |
+    +----------------+----------------------+------+
+    | Artist         |\e[34m Track                \e[0m| Year |
+    +----------------+----------------------+------+
+    | Konflict       |\e[31m Cyanide              \e[0m| 1999 |
+    | Keaton & Hive  |\e[31m The Plague           \e[0m| 2003 |
+    | Vicious Circle |\e[31m Welcome To Shanktown \e[0m| 2007 |
+    +----------------+----------------------+------+
+    """
+  end
+
+  test "default render with set column meta color across all columns and clear header", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_column_meta(1, color: :red)
+      |> Table.put_header_meta(1, color: :reset)
+      |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    |          Renegade Hardware Releases          |
+    +----------------+----------------------+------+
+    | Artist         |\e[0m Track                \e[0m| Year |
+    +----------------+----------------------+------+
+    | Konflict       |\e[31m Cyanide              \e[0m| 1999 |
+    | Keaton & Hive  |\e[31m The Plague           \e[0m| 2003 |
+    | Vicious Circle |\e[31m Welcome To Shanktown \e[0m| 2007 |
+    +----------------+----------------------+------+
+    """
+  end
  end

--- a/test/table_rex/table_test.exs
+++ b/test/table_rex/table_test.exs
@@ -89,13 +89,13 @@ defmodule TableRex.TableTest do
   test "adding a single row with cell structs", %{table: table} do
     row = [
       "Rascal & Klone",
-      %Cell{value: "The Grind", align: :left},
+      %Cell{value: "The Grind", align: :left, color: :red},
       %Cell{value: 2000, align: :right}
     ]
     table = Table.add_row(table, row)
     assert table.rows == [[
       %Cell{value: "Rascal & Klone"},
-      %Cell{value: "The Grind", align: :left},
+      %Cell{value: "The Grind", align: :left, color: :red},
       %Cell{value: "2000", align: :right}
     ]]
   end
@@ -107,7 +107,7 @@ defmodule TableRex.TableTest do
     ]
     additional_rows = [
       ["Aquasky", "Uptight", %Cell{value: 2000, align: :right}],
-      ["Dom & Roland", "Dance All Night", %Cell{value: 2004, align: :right}]
+      ["Dom & Roland", "Dance All Night", %Cell{value: 2004, align: :right, color: :red}]
     ]
     table = Table.add_rows(table, rows)
     table = Table.add_rows(table, additional_rows)
@@ -115,7 +115,7 @@ defmodule TableRex.TableTest do
       [
         %Cell{value: "Dom & Roland"},
         %Cell{value: "Dance All Night"},
-        %Cell{value: "2004", align: :right},
+        %Cell{value: "2004", align: :right, color: :red},
       ],
       [
         %Cell{value: "Aquasky"},
@@ -206,13 +206,13 @@ defmodule TableRex.TableTest do
   test "setting a header row with cell structs", %{table: table} do
     header_row = [
       "Artist",
-      %Cell{value: "Track", align: :left},
+      %Cell{value: "Track", align: :left, color: :red},
       %Cell{value: "Year", align: :right}
      ]
     table = Table.put_header(table, header_row)
     assert table.header_row == [
       %Cell{value: "Artist"},
-      %Cell{value: "Track", align: :left},
+      %Cell{value: "Track", align: :left, color: :red},
       %Cell{value: "Year", align: :right},
     ]
   end
@@ -237,10 +237,10 @@ defmodule TableRex.TableTest do
     assert table.columns == %{
       0 => %Column{align: :right}
     }
-    table = Table.put_column_meta(table, 0, align: :left, padding: 2)
+    table = Table.put_column_meta(table, 0, align: :left, padding: 2, color: :red)
     table = Table.put_column_meta(table, 1, align: :right)
     assert table.columns == %{
-      0 => %Column{align: :left, padding: 2},
+      0 => %Column{align: :left, padding: 2, color: :red},
       1 => %Column{align: :right}
     }
   end
@@ -265,6 +265,13 @@ defmodule TableRex.TableTest do
       1 => %Column{align: :right, padding: 4},
       2 => %Column{align: :right, padding: 4},
       3 => %Column{padding: 2}
+    }
+    table = Table.put_column_meta(table, [2, 3], color: :red)
+    assert table.columns == %{
+      0 => %Column{align: :right},
+      1 => %Column{align: :right, padding: 4},
+      2 => %Column{align: :right, padding: 4, color: :red},
+      3 => %Column{padding: 2, color: :red}
     }
   end
 
@@ -298,18 +305,20 @@ defmodule TableRex.TableTest do
       table
       |> Table.add_rows(rows)
       |> Table.put_cell_meta(0, 0, align: :right)
+      |> Table.put_cell_meta(0, 1, color: :red)
+      |> Table.put_cell_meta(1, 0, color: :red)
       |> Table.put_cell_meta(1, 1, align: :left)
 
     assert table.rows == [
       [
-        %Cell{value: "Calyx", align: nil},
-        %Cell{value: "Downpour", align: :left},
-        %Cell{value: "2001", align: nil}
+        %Cell{value: "Calyx", align: nil, color: :red},
+        %Cell{value: "Downpour", align: :left, color: nil},
+        %Cell{value: "2001", align: nil, color: nil}
       ],
       [
-        %Cell{value: "Dom & Roland", align: :right},
-        %Cell{value: "Thunder", align: nil},
-        %Cell{value: "1998", align: nil}
+        %Cell{value: "Dom & Roland", align: :right, color: nil},
+        %Cell{value: "Thunder", align: nil, color: :red},
+        %Cell{value: "1998", align: nil, color: nil}
       ]
     ]
   end
@@ -321,10 +330,11 @@ defmodule TableRex.TableTest do
       |> Table.put_header(header)
       |> Table.put_header_meta(0, align: :left)
       |> Table.put_header_meta(1, align: :right)
+      |> Table.put_header_meta(2, color: :red)
     assert table.header_row == [
-        %Cell{value: "Artist", align: :left},
-        %Cell{value: "Track", align: :right},
-        %Cell{value: "Year", align: nil}
+        %Cell{value: "Artist", align: :left, color: nil},
+        %Cell{value: "Track", align: :right, color: nil},
+        %Cell{value: "Year", align: nil, color: :red}
     ]
   end
 


### PR DESCRIPTION
This is nearly complete.  Still needs some documentation, though.

A couple of things to point out:
- When using a function, the text (value w/ padding) and the value are provided.  This allows one to conditionally assign color to a cell based on its value (w/o the padding).  Maybe in a future release **TableRex.Cell** can keep a copy of the original, raw value in addition to the string value.  This will save others from having to parse the value back to its original type.
- When putting color on the column, the header receives it as well.  To exclude the header, one needs to override the header with `:reset`.  Something that can be addressed in README.md.
- Without `put_title_meta`, there's no opportunity for the title to have color.  Guessing this will become a requested feature in the near future.