### PR TITLE
Widen table if required to accommodate title width.

### DIFF
--- a/lib/table_rex/renderer/text.ex
+++ b/lib/table_rex/renderer/text.ex
@@ -268,10 +268,17 @@ defmodule TableRex.Renderer.Text do
 
     num_columns = Map.size(col_widths)
 
-    # Compare table body width with title widths, including padding and borders
-    body_width = (col_widths |> Map.values |> Enum.sum) + num_columns + 1
-    title_width = (if is_nil(table.title), do: 0, else: String.length(table.title)) + 4
+    # Infer padding on left and right of title
+    title_padding = [0, num_columns - 1]
+    |> Enum.map(&(Table.get_column_meta(table, &1, :padding)))
+    |> Enum.sum
 
+    # Compare table body width with title width
+    col_separators_widths = num_columns - 1
+    body_width = (col_widths |> Map.values |> Enum.sum) + col_separators_widths
+    title_width = (if is_nil(table.title), do: 0, else: String.length(table.title)) + title_padding
+
+    # Add extra padding equally to all columns if required to match body and title width.
     revised_col_widths = if body_width >= title_width do
       col_widths
     else

--- a/lib/table_rex/renderer/text.ex
+++ b/lib/table_rex/renderer/text.ex
@@ -262,9 +262,24 @@ defmodule TableRex.Renderer.Text do
   end
 
   defp max_dimensions(%Table{} = table) do
-    [table.header_row | table.rows]
+    {col_widths, row_heights} = [table.header_row | table.rows]
     |> Enum.with_index
     |> Enum.reduce({%{}, %{}}, &reduce_row_maximums(table, &1, &2))
+
+    num_columns = Map.size(col_widths)
+
+    # Compare table body width with title widths, including padding and borders
+    body_width = (col_widths |> Map.values |> Enum.sum) + num_columns + 1
+    title_width = (if is_nil(table.title), do: 0, else: String.length(table.title)) + 4
+
+    revised_col_widths = if body_width >= title_width do
+      col_widths
+    else
+      extra_padding = ((title_width - body_width) / num_columns) |> Float.ceil |> round
+      Enum.into(col_widths, %{}, fn {k, v} -> { k, v + extra_padding } end)
+    end
+
+    {revised_col_widths, row_heights}
   end
 
   defp reduce_row_maximums(%Table{} = table, {row, row_index}, {col_widths, row_heights}) do

--- a/test/table_rex/renderer/text_test.exs
+++ b/test/table_rex/renderer/text_test.exs
@@ -1068,4 +1068,142 @@ defmodule TableRex.Renderer.TextTest do
     +----------------+----------------------+------+
     """
   end
+
+  test "default render with title that is one less than the combined column widths", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_title("Renegade Hardware Releases That Be Here Now")
+      |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    | Renegade Hardware Releases That Be Here Now  |
+    +----------------+----------------------+------+
+    | Artist         | Track                | Year |
+    +----------------+----------------------+------+
+    | Konflict       | Cyanide              | 1999 |
+    | Keaton & Hive  | The Plague           | 2003 |
+    | Vicious Circle | Welcome To Shanktown | 2007 |
+    +----------------+----------------------+------+
+    """
+  end
+
+  test "default render with title that exactly matches combined column widths", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_title("Renegade Hardware Releases That Are Here Now")
+      |> Table.render
+    assert rendered == """
+    +----------------------------------------------+
+    | Renegade Hardware Releases That Are Here Now |
+    +----------------+----------------------+------+
+    | Artist         | Track                | Year |
+    +----------------+----------------------+------+
+    | Konflict       | Cyanide              | 1999 |
+    | Keaton & Hive  | The Plague           | 2003 |
+    | Vicious Circle | Welcome To Shanktown | 2007 |
+    +----------------+----------------------+------+
+    """
+  end
+
+  test "default render with title that exceeds combined column widths by one space", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_title("Renegade Hardware Releases That Are Seen Here")
+      |> Table.render
+    assert rendered == """
+    +-------------------------------------------------+
+    |  Renegade Hardware Releases That Are Seen Here  |
+    +-----------------+-----------------------+-------+
+    | Artist          | Track                 | Year  |
+    +-----------------+-----------------------+-------+
+    | Konflict        | Cyanide               | 1999  |
+    | Keaton & Hive   | The Plague            | 2003  |
+    | Vicious Circle  | Welcome To Shanktown  | 2007  |
+    +-----------------+-----------------------+-------+
+    """
+  end
+
+  test "default render with title that significantly exceeds combined column widths", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_title("Renegade Hardware Releases That Are Present In This Table")
+      |> Table.render
+    assert rendered == """
+    +-------------------------------------------------------------+
+    |  Renegade Hardware Releases That Are Present In This Table  |
+    +---------------------+---------------------------+-----------+
+    | Artist              | Track                     | Year      |
+    +---------------------+---------------------------+-----------+
+    | Konflict            | Cyanide                   | 1999      |
+    | Keaton & Hive       | The Plague                | 2003      |
+    | Vicious Circle      | Welcome To Shanktown      | 2007      |
+    +---------------------+---------------------------+-----------+
+    """
+  end
+
+  test "default render with title exceeding combined column widths by multiple of number of columns", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_title("Renegade Hardware Releases Seen In This Very Table")
+      |> Table.render
+    assert rendered == """
+    +----------------------------------------------------+
+    | Renegade Hardware Releases Seen In This Very Table |
+    +------------------+------------------------+--------+
+    | Artist           | Track                  | Year   |
+    +------------------+------------------------+--------+
+    | Konflict         | Cyanide                | 1999   |
+    | Keaton & Hive    | The Plague             | 2003   |
+    | Vicious Circle   | Welcome To Shanktown   | 2007   |
+    +------------------+------------------------+--------+
+    """
+  end
+
+  test "default render with title exactly matching combined column widths when only 2 columns" do
+    title = "Renegade Hardware Releases Shown Here"
+    header = ["Artist", "Track"]
+    rows = [
+      ["Konflict", "Cyanide"],
+      ["Keaton & Hive", "The Plague"],
+      ["Vicious Circle", "Welcome To Shanktown"]
+    ]
+    {:ok, rendered} = Table.new(rows, header, title)
+    |> Table.render
+
+    assert rendered === """
+    +---------------------------------------+
+    | Renegade Hardware Releases Shown Here |
+    +----------------+----------------------+
+    | Artist         | Track                |
+    +----------------+----------------------+
+    | Konflict       | Cyanide              |
+    | Keaton & Hive  | The Plague           |
+    | Vicious Circle | Welcome To Shanktown |
+    +----------------+----------------------+
+    """
+  end
+
+  test "default render with title exceeding combined column widths by one space when only 2 columns" do
+    title = "Renegade Hardware Releases Shown Here!"
+    header = ["Artist", "Track"]
+    rows = [
+      ["Konflict", "Cyanide"],
+      ["Keaton & Hive", "The Plague"],
+      ["Vicious Circle", "Welcome To Shanktown"]
+    ]
+    {:ok, rendered} = Table.new(rows, header, title)
+    |> Table.render
+
+    assert rendered === """
+    +-----------------------------------------+
+    | Renegade Hardware Releases Shown Here!  |
+    +-----------------+-----------------------+
+    | Artist          | Track                 |
+    +-----------------+-----------------------+
+    | Konflict        | Cyanide               |
+    | Keaton & Hive   | The Plague            |
+    | Vicious Circle  | Welcome To Shanktown  |
+    +-----------------+-----------------------+
+    """
  end
+end

--- a/test/table_rex/renderer/text_test.exs
+++ b/test/table_rex/renderer/text_test.exs
@@ -1105,7 +1105,7 @@ defmodule TableRex.Renderer.TextTest do
     """
   end
 
-  test "default render with title that exceeds combined column widths by one space", %{table: table} do
+  test "default render with title that exceeds combined column widths by 1 character", %{table: table} do
     {:ok, rendered} =
       table
       |> Table.put_title("Renegade Hardware Releases That Are Seen Here")
@@ -1123,7 +1123,7 @@ defmodule TableRex.Renderer.TextTest do
     """
   end
 
-  test "default render with title that significantly exceeds combined column widths", %{table: table} do
+  test "default render with title that far exceeds combined column widths", %{table: table} do
     {:ok, rendered} =
       table
       |> Table.put_title("Renegade Hardware Releases That Are Present In This Table")
@@ -1137,6 +1137,27 @@ defmodule TableRex.Renderer.TextTest do
     | Konflict            | Cyanide                   | 1999      |
     | Keaton & Hive       | The Plague                | 2003      |
     | Vicious Circle      | Welcome To Shanktown      | 2007      |
+    +---------------------+---------------------------+-----------+
+    """
+  end
+
+  test "default render with title that far exceeds combined column widths with irregular alignments", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_title("Renegade Hardware Releases That Are Present In This Table")
+      |> Table.put_column_meta(0, align: :right)
+      |> Table.put_column_meta(1, align: :center)
+      |> Table.render
+
+    assert rendered == """
+    +-------------------------------------------------------------+
+    |  Renegade Hardware Releases That Are Present In This Table  |
+    +---------------------+---------------------------+-----------+
+    |              Artist |           Track           | Year      |
+    +---------------------+---------------------------+-----------+
+    |            Konflict |          Cyanide          | 1999      |
+    |       Keaton & Hive |        The Plague         | 2003      |
+    |      Vicious Circle |   Welcome To Shanktown    | 2007      |
     +---------------------+---------------------------+-----------+
     """
   end
@@ -1183,7 +1204,7 @@ defmodule TableRex.Renderer.TextTest do
     """
   end
 
-  test "default render with title exceeding combined column widths by one space when only 2 columns" do
+  test "default render with title exceeding combined column widths by 1 character when only 2 columns" do
     title = "Renegade Hardware Releases Shown Here!"
     header = ["Artist", "Track"]
     rows = [
@@ -1205,5 +1226,63 @@ defmodule TableRex.Renderer.TextTest do
     | Vicious Circle  | Welcome To Shanktown  |
     +-----------------+-----------------------+
     """
- end
+  end
+
+  test "minimal render (zero padding) with title exceeding combined column widths", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_title("Renegade Hardware Releases That Are Present In This Table")
+      |> Table.put_column_meta(:all, padding: 0)
+      |> Table.render(horizontal_style: :off, vertical_style: :off)
+
+    assert rendered == """
+    Renegade Hardware Releases That Are Present In This Table
+
+    Artist               Track                      Year
+
+    Konflict             Cyanide                    1999
+    Keaton & Hive        The Plague                 2003
+    Vicious Circle       Welcome To Shanktown       2007
+    """
+  end
+
+  test "render with vertical style: frame with title exceeding combined column widths", %{table: table} do
+    {:ok, rendered} = table
+    |> Table.put_title("Renegade Hardware Releases That Are Present In This Table")
+    |> Table.render(vertical_style: :frame)
+
+    assert rendered == """
+    +-------------------------------------------------------------+
+    |  Renegade Hardware Releases That Are Present In This Table  |
+    +-------------------------------------------------------------+
+    | Artist                Track                       Year      |
+    +-------------------------------------------------------------+
+    | Konflict              Cyanide                     1999      |
+    | Keaton & Hive         The Plague                  2003      |
+    | Vicious Circle        Welcome To Shanktown        2007      |
+    +-------------------------------------------------------------+
+    """
+  end
+
+  test "render with irregular column paddings with title exceeding combined column widths", %{table: table} do
+    {:ok, rendered} =
+      table
+      |> Table.put_title("Renegade Hardware Releases That Are Present In This Table")
+      |> Table.put_column_meta(0..1, padding: 0)
+      |> Table.put_column_meta(2, padding: 1)
+      |> Table.render
+
+    assert rendered == """
+    +------------------------------------------------------------+
+    | Renegade Hardware Releases That Are Present In This Table  |
+    +--------------------+--------------------------+------------+
+    |Artist              |Track                     | Year       |
+    +--------------------+--------------------------+------------+
+    |Konflict            |Cyanide                   | 1999       |
+    |Keaton & Hive       |The Plague                | 2003       |
+    |Vicious Circle      |Welcome To Shanktown      | 2007       |
+    +--------------------+--------------------------+------------+
+    """
+  end
+
 end


### PR DESCRIPTION
Add extra padding equally to all columns until the table is
wide enough to accommodate title.

Fixes https://github.com/djm/table_rex/issues/13.