### PR TITLE
Strip ANSI codes when determining cell width

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,5 +9,6 @@ Contributors
 * **[Charles FD](https://github.com/freiden)**
 * **[Justin G](https://github.com/theredcoder)**
 * **[Matt Harvey](https://github.com/matt-harvey)**
+* **[Geoffrey Lessel](https://github.com/geolessel)**
 
 Please add yourself if making a contribution.

--- a/lib/table_rex/renderer/text.ex
+++ b/lib/table_rex/renderer/text.ex
@@ -227,14 +227,14 @@ defmodule TableRex.Renderer.Text do
   end
 
   defp do_render_cell(value, inner_width, _padding, align: :center) do
-    value_len = String.length(value)
+    value_len = String.length(strip_ansi_color_codes(value))
     post_value = ((inner_width - value_len) / 2) |> round
     pre_value = inner_width - (post_value + value_len)
     String.duplicate(" ", pre_value) <> value <> String.duplicate(" ", post_value)
   end
 
   defp do_render_cell(value, inner_width, padding, align: align) do
-    value_len = String.length(value)
+    value_len = String.length(strip_ansi_color_codes(value))
     alt_side_padding = inner_width - value_len - padding
     {pre_value, post_value} = case align do
       :left ->
@@ -304,7 +304,10 @@ defmodule TableRex.Renderer.Text do
   end
 
   defp content_dimensions(value, padding) when is_binary(value) and is_number(padding) do
-    lines = String.split(value, "\n")
+    lines =
+      value
+      |> strip_ansi_color_codes()
+      |> String.split("\n")
     height = Enum.count(lines)
     width = Enum.max(lines) |> String.length
     {width + (padding * 2), height}
@@ -348,5 +351,9 @@ defmodule TableRex.Renderer.Text do
   defp format_with_color(text, _, color) do
     [[color | text] | IO.ANSI.reset]
     |> IO.ANSI.format_fragment(true)
+  end
+
+  defp strip_ansi_color_codes(text) do
+    Regex.replace(~r|\e\[\d+m|u, text, "")
   end
 end

--- a/test/table_rex/renderer/text_test.exs
+++ b/test/table_rex/renderer/text_test.exs
@@ -1228,6 +1228,32 @@ defmodule TableRex.Renderer.TextTest do
     """
   end
 
+  test "default render with individual cells containing ANSI color codes" do
+    title = "Renegade Hardware Releases"
+    header = ["Artist", "Track", "Year"]
+    rows = [
+      ["Konflict", "Cyanide", IO.ANSI.format([:red, "19", :bright, "99"])],
+      ["Keaton & Hive", "The Plague", 2003],
+      ["Vicious Circle", "Welcome To Shanktown", IO.ANSI.format(["200", :green, "7"])],
+    ]
+    {:ok, rendered} =
+      rows
+      |> Table.new(header, title)
+      |> Table.render()
+
+    assert rendered === """
+    +----------------------------------------------+
+    |          Renegade Hardware Releases          |
+    +----------------+----------------------+------+
+    | Artist         | Track                | Year |
+    +----------------+----------------------+------+
+    | Konflict       | Cyanide              | \e[31m19\e[1m99\e[0m |
+    | Keaton & Hive  | The Plague           | 2003 |
+    | Vicious Circle | Welcome To Shanktown | 200\e[32m7\e[0m |
+    +----------------+----------------------+------+
+    """
+  end
+
   test "minimal render (zero padding) with title exceeding combined column widths", %{table: table} do
     {:ok, rendered} =
       table
@@ -1284,5 +1310,4 @@ defmodule TableRex.Renderer.TextTest do
     +--------------------+--------------------------+------------+
     """
   end
-
 end


### PR DESCRIPTION
I'd like to have some ANSI color codes _inside_ an individual cell (as opposed to having the whole cell styled by the ANSI code). Previously, this messed up the calculation of the cell width since the ANSI codes themselves were included in the width calculation. This strips out the ANSI color codes when determining the width of the cell.

This could (should?) probably be expanded to also include other ANSI codes.

Here's a before/after with an app I'm working on.

## before

![screenshot 2018-04-23 12 11 49](https://user-images.githubusercontent.com/385726/39147809-836fbb68-46ef-11e8-9acd-af8c1aecac82.png)


## after

![screenshot 2018-04-23 12 10 50](https://user-images.githubusercontent.com/385726/39147763-69ffa328-46ef-11e8-9fa0-5642fa1bcb01.png)
