### PR TITLE
Fix spec for TableRex.Title.new/3

### DIFF
--- a/lib/table_rex/table.ex
+++ b/lib/table_rex/table.ex
@@ -34,7 +34,7 @@ defmodule TableRex.Table do
   @doc """
   Creates a new table with an initial set of rows and an optional header and title.
   """
-  @spec new(list, list, String.t()) :: Table.t()
+  @spec new(list, list, String.t() | nil) :: Table.t()
   def new(rows, header_row \\ [], title \\ nil) when is_list(rows) and is_list(header_row) do
     new()
     |> put_title(title)


### PR DESCRIPTION
`TableRex.Title.new/3` allows the title to be `nil`. As `TableRex.quick_render/3` allows the title to be `nil` in its spec, this should be reflected in the spec for `new/3` as well.