### PR TITLE
Fix Map.size deprecation warning

### DIFF
--- a/lib/table_rex/renderer/text.ex
+++ b/lib/table_rex/renderer/text.ex
@@ -341,7 +341,7 @@ defmodule TableRex.Renderer.Text do
       |> Enum.with_index()
       |> Enum.reduce({%{}, %{}}, &reduce_row_maximums(table, &1, &2))
 
-    num_columns = Map.size(col_widths)
+    num_columns = map_size(col_widths)
 
     # Infer padding on left and right of title
     title_padding =


### PR DESCRIPTION
    warning: Map.size/1 is deprecated. Use Kernel.map_size/1 instead
      lib/table_rex/renderer/text.ex:344: TableRex.Renderer.Text.max_dimensions/1

The `Map.size/1` function has been deprecated since Elixir `1.3.0` and `Kernel.map_size/1` is available since `0.13.0`, so it's a safe upgrade.