### PR TITLE
Fix column max width calculation

### DIFF
--- a/lib/table_rex/renderer/text.ex
+++ b/lib/table_rex/renderer/text.ex
@@ -402,7 +402,7 @@ defmodule TableRex.Renderer.Text do
       |> String.split("\n")
 
     height = Enum.count(lines)
-    width = Enum.max(lines) |> String.length()
+    width = lines |> Enum.map(&String.length/1) |> Enum.max()
     {width + padding * 2, height}
   end
 

--- a/test/table_rex/renderer/text_test.exs
+++ b/test/table_rex/renderer/text_test.exs
@@ -1350,6 +1350,20 @@ defmodule TableRex.Renderer.TextTest do
              +----------------+----------------------+--------------------------+------+
              """
     end
+
+    test "rendering lines with different lengths" do
+      {:ok, rendered} =
+        [["aaa\nb", "a\nbbb"]]
+        |> Table.new()
+        |> Table.render()
+
+      assert rendered == """
+             +-----+-----+
+             | aaa | a   |
+             | b   | bbb |
+             +-----+-----+
+             """
+    end
   end
 
   test "default render with header cell color", %{table: table} do


### PR DESCRIPTION
Fixes #41

> [Enum.max] Returns the maximal element in the enumerable according to Erlang's term ordering.

```elixir
Enum.max(["aa", "b"])
"b"
```