### PR TITLE
Row colors added for any number of styles for font and background

### DIFF
--- a/lib/table_rex/table.ex
+++ b/lib/table_rex/table.ex
@@ -294,4 +294,19 @@ defmodule TableRex.Table do
       {:error, reason} -> raise TableRex.Error, message: reason
     end
   end
+
+  def row_colors result, colors do
+    %{result | rows: map_colors(Map.get(result, :rows), colors)}
+  end
+
+  defp map_colors rows, colors do
+      n = Enum.count colors
+      rows
+      |> Enum.with_index
+      |> Enum.map(fn {list,i} -> Enum.map(list, fn x ->
+          color = Enum.at(colors, rem(i,n))
+          %{x | color: color}
+        end)
+      end)
+  end
 end

--- a/lib/table_rex/table.ex
+++ b/lib/table_rex/table.ex
@@ -295,18 +295,20 @@ defmodule TableRex.Table do
     end
   end
 
-  def row_colors result, colors do
+  def row_colors(result, colors) do
     %{result | rows: map_colors(Map.get(result, :rows), colors)}
   end
 
-  defp map_colors rows, colors do
-      n = Enum.count colors
-      rows
-      |> Enum.with_index
-      |> Enum.map(fn {list,i} -> Enum.map(list, fn x ->
-          color = Enum.at(colors, rem(i,n))
-          %{x | color: color}
-        end)
+  defp map_colors(rows, colors) do
+    n = Enum.count(colors)
+
+    rows
+    |> Enum.with_index()
+    |> Enum.map(fn {list, i} ->
+      Enum.map(list, fn x ->
+        color = Enum.at(colors, rem(i, n))
+        %{x | color: color}
       end)
+    end)
   end
 end

--- a/test/table_rex/renderer/text_test.exs
+++ b/test/table_rex/renderer/text_test.exs
@@ -1698,25 +1698,26 @@ defmodule TableRex.Renderer.TextTest do
   end
 
   test "render with choice row colors" do
-
     title = "Drum & Bass Releases"
     header = ["Artist", "Track", "Label", "Year"]
+
     rows = [
       ["Konflict", "Cyanide", "Renegade Hardware", 1999],
       ["Marcus Intalex", "Temperance", "Soul:r", 2004],
       ["Kryptic Minds", "The Forgotten", "Defcom Records", 2007],
       ["Konflict", "Cyanide", "Renegade Hardware", 1999],
       ["Marcus Intalex", "Temperance", "Soul:r", 2004],
-      ["Kryptic Minds", "The Forgotten", "Defcom Records", 2007],
+      ["Kryptic Minds", "The Forgotten", "Defcom Records", 2007]
     ]
 
-    {:ok, rendered} = Table.new(rows, header,title)
-    |> Table.put_header_meta(0..4, color: :light_blue)
-    |> Table.row_colors([:light_yellow, [:black, :green_background], :light_magenta])
-    |> Table.render
+    {:ok, rendered} =
+      Table.new(rows, header, title)
+      |> Table.put_header_meta(0..4, color: :light_blue)
+      |> Table.row_colors([:light_yellow, [:black, :green_background], :light_magenta])
+      |> Table.render()
 
     assert rendered == """
-+-----------------------------------------------------------+\n|                   Drum & Bass Releases                    |\n+----------------+---------------+-------------------+------+\n|\e[94m Artist         \e[0m|\e[94m Track         \e[0m|\e[94m Label             \e[0m|\e[94m Year \e[0m|\n+----------------+---------------+-------------------+------+\n|\e[95m Konflict       \e[0m|\e[95m Cyanide       \e[0m|\e[95m Renegade Hardware \e[0m|\e[95m 1999 \e[0m|\n|\e[30m\e[42m Marcus Intalex \e[0m|\e[30m\e[42m Temperance    \e[0m|\e[30m\e[42m Soul:r            \e[0m|\e[30m\e[42m 2004 \e[0m|\n|\e[93m Kryptic Minds  \e[0m|\e[93m The Forgotten \e[0m|\e[93m Defcom Records    \e[0m|\e[93m 2007 \e[0m|\n|\e[95m Konflict       \e[0m|\e[95m Cyanide       \e[0m|\e[95m Renegade Hardware \e[0m|\e[95m 1999 \e[0m|\n|\e[30m\e[42m Marcus Intalex \e[0m|\e[30m\e[42m Temperance    \e[0m|\e[30m\e[42m Soul:r            \e[0m|\e[30m\e[42m 2004 \e[0m|\n|\e[93m Kryptic Minds  \e[0m|\e[93m The Forgotten \e[0m|\e[93m Defcom Records    \e[0m|\e[93m 2007 \e[0m|\n+----------------+---------------+-------------------+------+
-"""
+           +-----------------------------------------------------------+\n|                   Drum & Bass Releases                    |\n+----------------+---------------+-------------------+------+\n|\e[94m Artist         \e[0m|\e[94m Track         \e[0m|\e[94m Label             \e[0m|\e[94m Year \e[0m|\n+----------------+---------------+-------------------+------+\n|\e[95m Konflict       \e[0m|\e[95m Cyanide       \e[0m|\e[95m Renegade Hardware \e[0m|\e[95m 1999 \e[0m|\n|\e[30m\e[42m Marcus Intalex \e[0m|\e[30m\e[42m Temperance    \e[0m|\e[30m\e[42m Soul:r            \e[0m|\e[30m\e[42m 2004 \e[0m|\n|\e[93m Kryptic Minds  \e[0m|\e[93m The Forgotten \e[0m|\e[93m Defcom Records    \e[0m|\e[93m 2007 \e[0m|\n|\e[95m Konflict       \e[0m|\e[95m Cyanide       \e[0m|\e[95m Renegade Hardware \e[0m|\e[95m 1999 \e[0m|\n|\e[30m\e[42m Marcus Intalex \e[0m|\e[30m\e[42m Temperance    \e[0m|\e[30m\e[42m Soul:r            \e[0m|\e[30m\e[42m 2004 \e[0m|\n|\e[93m Kryptic Minds  \e[0m|\e[93m The Forgotten \e[0m|\e[93m Defcom Records    \e[0m|\e[93m 2007 \e[0m|\n+----------------+---------------+-------------------+------+
+           """
   end
 end

--- a/test/table_rex/renderer/text_test.exs
+++ b/test/table_rex/renderer/text_test.exs
@@ -1696,4 +1696,27 @@ defmodule TableRex.Renderer.TextTest do
            +--------------------+--------------------------+------------+
            """
   end
+
+  test "render with choice row colors" do
+
+    title = "Drum & Bass Releases"
+    header = ["Artist", "Track", "Label", "Year"]
+    rows = [
+      ["Konflict", "Cyanide", "Renegade Hardware", 1999],
+      ["Marcus Intalex", "Temperance", "Soul:r", 2004],
+      ["Kryptic Minds", "The Forgotten", "Defcom Records", 2007],
+      ["Konflict", "Cyanide", "Renegade Hardware", 1999],
+      ["Marcus Intalex", "Temperance", "Soul:r", 2004],
+      ["Kryptic Minds", "The Forgotten", "Defcom Records", 2007],
+    ]
+
+    {:ok, rendered} = Table.new(rows, header,title)
+    |> Table.put_header_meta(0..4, color: :light_blue)
+    |> Table.row_colors([:light_yellow, [:black, :green_background], :light_magenta])
+    |> Table.render
+
+    assert rendered == """
++-----------------------------------------------------------+\n|                   Drum & Bass Releases                    |\n+----------------+---------------+-------------------+------+\n|\e[94m Artist         \e[0m|\e[94m Track         \e[0m|\e[94m Label             \e[0m|\e[94m Year \e[0m|\n+----------------+---------------+-------------------+------+\n|\e[95m Konflict       \e[0m|\e[95m Cyanide       \e[0m|\e[95m Renegade Hardware \e[0m|\e[95m 1999 \e[0m|\n|\e[30m\e[42m Marcus Intalex \e[0m|\e[30m\e[42m Temperance    \e[0m|\e[30m\e[42m Soul:r            \e[0m|\e[30m\e[42m 2004 \e[0m|\n|\e[93m Kryptic Minds  \e[0m|\e[93m The Forgotten \e[0m|\e[93m Defcom Records    \e[0m|\e[93m 2007 \e[0m|\n|\e[95m Konflict       \e[0m|\e[95m Cyanide       \e[0m|\e[95m Renegade Hardware \e[0m|\e[95m 1999 \e[0m|\n|\e[30m\e[42m Marcus Intalex \e[0m|\e[30m\e[42m Temperance    \e[0m|\e[30m\e[42m Soul:r            \e[0m|\e[30m\e[42m 2004 \e[0m|\n|\e[93m Kryptic Minds  \e[0m|\e[93m The Forgotten \e[0m|\e[93m Defcom Records    \e[0m|\e[93m 2007 \e[0m|\n+----------------+---------------+-------------------+------+
+"""
+  end
 end


### PR DESCRIPTION
I made an enhancement by adding Alternating Row colors for any number of styles for font and background.
![trex](https://user-images.githubusercontent.com/39833360/112991670-4cb84f00-915f-11eb-8128-ff5fce75954e.png)
![trex01](https://user-images.githubusercontent.com/39833360/112991690-5346c680-915f-11eb-8e97-9377ac787e45.png)
![trex02](https://user-images.githubusercontent.com/39833360/112991713-5b9f0180-915f-11eb-9e90-cfd3c72dcbe3.png)
![trex03](https://user-images.githubusercontent.com/39833360/112991722-5e015b80-915f-11eb-93da-c990f5522f60.png)

Please accept my contribution in this Pull request.
Regards


