### PR TITLE
Update for Elixir v1.15

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -3,6 +3,8 @@ name: TableRex CI
 on: push
 
 jobs:
+  # Official support is for latest 3 minor Elixir
+  # versions & latest 2 major OTP releases.
   elixir_1_15:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Run the test suite
         run: mix test
 
+
   elixir_1_14:
     runs-on: ubuntu-latest
 
@@ -43,6 +44,38 @@ jobs:
       matrix:
         otp: [24.x, 25.x]
         elixir: [1.14.x]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Compile & error on warning
+        run: mix compile --warnings-as-errors
+
+      - name: Check code is formatted
+        run: mix format --check-formatted
+
+      - name: Run the test suite
+        run: mix test
+
+
+  elixir_1_13:
+    runs-on: ubuntu-latest
+
+    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+
+    strategy:
+      matrix:
+        otp: [24.x, 25.x]
+        elixir: [1.13.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,83 +1,21 @@
 name: TableRex CI
 
 on: push
-
 jobs:
-  # Official support is for latest 3 minor Elixir
-  # versions & latest 2 major OTP releases.
-  elixir_1_15:
+  build:
     runs-on: ubuntu-latest
-
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
 
     strategy:
       matrix:
-        otp: [24.x, 25.x, 26.x]
-        elixir: [1.15.x]
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Elixir
-        uses: erlef/setup-beam@v1
-        with:
-          elixir-version: ${{ matrix.elixir }}
-          otp-version: ${{ matrix.otp }}
-
-      - name: Install dependencies
-        run: mix deps.get
-
-      - name: Compile & error on warning
-        run: mix compile --warnings-as-errors
-
-      - name: Check code is formatted
-        run: mix format --check-formatted
-
-      - name: Run the test suite
-        run: mix test
-
-
-  elixir_1_14:
-    runs-on: ubuntu-latest
-
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
-
-    strategy:
-      matrix:
-        otp: [24.x, 25.x]
-        elixir: [1.14.x]
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Elixir
-        uses: erlef/setup-beam@v1
-        with:
-          elixir-version: ${{ matrix.elixir }}
-          otp-version: ${{ matrix.otp }}
-
-      - name: Install dependencies
-        run: mix deps.get
-
-      - name: Compile & error on warning
-        run: mix compile --warnings-as-errors
-
-      - name: Check code is formatted
-        run: mix format --check-formatted
-
-      - name: Run the test suite
-        run: mix test
-
-
-  elixir_1_13:
-    runs-on: ubuntu-latest
-
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
-
-    strategy:
-      matrix:
-        otp: [24.x, 25.x]
-        elixir: [1.13.x]
+        # Official support is for latest 3 minor Elixir
+        # versions & latest 2 major OTP releases.
+        elixir: ["1.13", "1.14", "1.15"]
+        otp: ["25", "26"]
+        exclude:
+          - elixir: 1.13
+            otp: 26
+          - elixir: 1.14
+            otp: 26
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -3,18 +3,49 @@ name: TableRex CI
 on: push
 
 jobs:
-  build:
+  elixir_1_15:
     runs-on: ubuntu-latest
+
+    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
 
     strategy:
       matrix:
-        # Official support is for latest 3 minor Elixir
-        # versions & latest 2 major OTP releases.
-        elixir: ["1.13", "1.14", "1.15"]
-        otp: ["25", "26"]
+        otp: [24.x, 25.x, 26.x]
+        elixir: [1.15.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: Setup Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Compile & error on warning
+        run: mix compile --warnings-as-errors
+
+      - name: Check code is formatted
+        run: mix format --check-formatted
+
+      - name: Run the test suite
+        run: mix test
+
+  elixir_1_14:
+    runs-on: ubuntu-latest
+
+    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+
+    strategy:
+      matrix:
+        otp: [24.x, 25.x]
+        elixir: [1.14.x]
+
+    steps:
+      - uses: actions/checkout@v3
 
       - name: Setup Elixir
         uses: erlef/setup-beam@v1

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,10 +1,6 @@
 name: TableRex CI
 
-on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+on: push
 
 jobs:
   build:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,14 +14,14 @@ jobs:
       matrix:
         # Official support is for latest 3 minor Elixir
         # versions & latest 2 major OTP releases.
-        elixir: ["1.8", "1.9", "1.10"]
-        otp: ["21", "22"]
+        elixir: ["1.13", "1.14", "1.15"]
+        otp: ["25", "26"]
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Setup Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}


### PR DESCRIPTION
Hey, 

I have updated the CI to use the last 3 current Elixir version using the support matrix [found here](https://github.com/elixir-lang/elixir/blob/main/lib/elixir/pages/compatibility-and-deprecations.md) and also the versions that the `ubuntu-latest` - 22.04 supports from [here](https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp) 

Please let me know if you would like any changes? 

Thanks
Sam 