### PR TITLE
Fix Elixir 1.17 warning about function call without parens

### DIFF
--- a/lib/table_rex/table.ex
+++ b/lib/table_rex/table.ex
@@ -264,7 +264,7 @@ defmodule TableRex.Table do
   @spec render(Table.t(), list) :: Renderer.render_return()
   def render(%Table{} = table, opts \\ []) when is_list(opts) do
     {renderer, opts} = Keyword.pop(opts, :renderer, @default_renderer)
-    opts = opts |> Enum.into(renderer.default_options)
+    opts = opts |> Enum.into(renderer.default_options())
     renderer.render(table, opts)
   end
 


### PR DESCRIPTION
In 5f45b8bce8fe7ba7d33e2bc434558e54efc5f34e I've fixed a warning about invoking a function without parentheses. It shows at run-time and looks like this:
```
warning: using map.field notation (without parentheses) to invoke function TableRex.Renderer.Text.default_options() is deprecated, you must add parentheses instead: remote.function()
  (table_rex 4.0.0) lib/table_rex/table.ex:267: TableRex.Table.render/2
  (table_rex 4.0.0) lib/table_rex/table.ex:280: TableRex.Table.render!/2
```