### PR TITLE
Fix Elixir 1.20 compilation warnings

### DIFF
--- a/lib/table_rex/renderer/text.ex
+++ b/lib/table_rex/renderer/text.ex
@@ -308,8 +308,7 @@ defmodule TableRex.Renderer.Text do
     cell_align = Map.get(cell, :align) || Table.get_column_meta(table, col_index, :align)
     cell_color = Map.get(cell, :color) || Table.get_column_meta(table, col_index, :color)
 
-    cell_width_calc =
-      Map.get(cell, :width_calc, nil) || Table.get_column_meta(table, col_index, :width_calc)
+    cell_width_calc = Table.get_column_meta(table, col_index, :width_calc)
 
     do_render_cell(cell.rendered_value, col_width, col_padding,
       align: cell_align,


### PR DESCRIPTION
Resolve compilation warnings introduced in Elixir 1.20.

- Fixed `Map.get(cell, :width_calc, nil)` which always returns nil on a `%Cell{}` struct (the struct doesn't have a `:width_calc` key). Replaced with direct `Table.get_column_meta/3` call.